### PR TITLE
Fix handling of file names with spaces

### DIFF
--- a/PKGBUILD.template
+++ b/PKGBUILD.template
@@ -26,7 +26,7 @@ package() {
 
   wrapper="whisper.cpp-${_model}"
   echo "#!/bin/sh
-/usr/bin/whisper.cpp --model ${modelpath} "'$@' > "$srcdir/$wrapper"
+/usr/bin/whisper.cpp --model ${modelpath} "\"'$@'\" > "$srcdir/$wrapper"
   install -Dm755 "${srcdir}/$wrapper" "$pkgdir/usr/bin/$wrapper"
 
 


### PR DESCRIPTION
I haven't checked if this works in the makepkg yet but basically I've added "" quotes around  `$@` to better handle filenames with spaces.