### PR TITLE
Add `git` to `makedepends`

### DIFF
--- a/PKGBUILD.template
+++ b/PKGBUILD.template
@@ -7,7 +7,7 @@ arch=("i686" "x86_64")
 url="https://github.com/ggerganov/whisper.cpp/tree/master/models"
 license=("MIT")
 
-makedepends=()
+makedepends=("git")
 depends=()
 conflicts=()
 provides=()


### PR DESCRIPTION
The `git` package is not part of the [`base`](https://archlinux.org/packages/core/any/base/) nor the [`base-devel`](https://archlinux.org/packages/core/any/base-devel/) meta-packages which are the only packages that can be assumed to be installed by a `PKGBUILD`. If it is not explicitly specified in the `makedepends` array then the package fails to build in a clean chroot with the following errors:

```
==> ERROR: pkgver is not allowed to contain colons, forward slashes, hyphens or whitespace.
==> ERROR: pkgver() generated an invalid version: /startdir/PKGBUILD: line 12: git: command not found
```