### PR TITLE
Fix SHA256 being stored as SHA1

### DIFF
--- a/PKGBUILD.template
+++ b/PKGBUILD.template
@@ -32,7 +32,7 @@ __model_url() {
 }
 
 source=("$_model_file::$(__model_url $_model)")
-sha1sums=("$_model_sha1sum")
+sha256sums=("$_model_sha256sum")
 
 
 package() {

--- a/generate.py
+++ b/generate.py
@@ -204,7 +204,7 @@ if __name__ == '__main__':
         model_src = [
             var('_baseurl', repo_url),
             var('_model', model_name),
-            var('_model_sha1sum', checksum),
+            var('_model_sha256sum', checksum),
             var('_pkgbase', _pkgbase),
             #var('_download_script_url', download_script_url),
             #var('_download_script_basename', download_script_basename),


### PR DESCRIPTION
Fix `generate.py` computing SHA256 hash but storing it as SHA1 in `PKGBUILD`, which causes validation errors at build time. SHA256 is still computed, but is now stored in the `sha256sums` array instead of `sha1sums`.